### PR TITLE
Update CLI to use newer AWI Proxy config

### DIFF
--- a/cmd/listVpn.go
+++ b/cmd/listVpn.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	awi "github.com/app-net-interface/awi-grpc/pb"
+	"github.com/spf13/cobra"
 
 	"github.com/app-net-interface/awi-cli/prettyprint"
 )

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,17 @@ controllers:
     vendor: cisco
 globals:
   db_name: awi.db
-#  log_file: tmp.log
+  # The name of the log_file to dump logs.
+  #
+  # If not specified, the awi-cli will use STDOUT to log.
+  log_file: ""
   log_level: ERROR
-  grpc_url: "[::1]:8080" # can be changed to localhost:8080 for IPv4
+  # The address of a controller or the proxy.
+  #
+  # Can be changed to localhost:8080 for IPv4
+  grpc_url: "[::1]:80"
+  # use_proxy indicates that the awi-cli will use proxy server rather
+  # than calling Controller directly. The difference is that proxy
+  # expects backend calls to start with /grpc prefix and such prefix
+  # will be added to every call.
+  use_proxy: true


### PR DESCRIPTION
Since the Envoy Proxy became a front for the application installed by the awi-install on the k8s cluster, the front-end and back-end calls were distinguished by adding /grpc prefix to every back-end call.

This change adds "use_proxy" option in configuration - when enabled it will automatically add /grpc prefix to every call performed by its GRPC Client. To keep the option of calling awi-grpc-catalyst-sdwan controller directly, this option can be disabled and thus this prefix won't be added.

The change also removes some unused methods.